### PR TITLE
Fix return type in moveFile

### DIFF
--- a/lib/WifiDirect.dart
+++ b/lib/WifiDirect.dart
@@ -882,14 +882,13 @@ getProgress(double v){
       },
     );
   }
-  Future<bool> moveFile(String uri, String fileName) async {
+  Future<void> moveFile(String uri, String fileName) async {
     try {
-      await platform.invokeMethod("Save",<String,String>{
-        'name':fileName,
-        'uri':uri
+      await platform.invokeMethod("Save", <String, String>{
+        'name': fileName,
+        'uri': uri,
       });
-
-    }catch (e){
+    } catch (e) {
       print("Rename error $e");
     }
   }


### PR DESCRIPTION
## Summary
- fix the return type of `moveFile` to return `Future<void>`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2a901658832cb714cb473ff57aef